### PR TITLE
make sure db sync is finshed before nova service restart

### DIFF
--- a/roles/nova-controller/handlers/main.yml
+++ b/roles/nova-controller/handlers/main.yml
@@ -20,8 +20,5 @@
 - name: remove nova-sqlite-db
   shell: rm /var/lib/nova/nova.sqlite || touch nova.sqlite.db.removed
 
-- name: sync nova-manage-db
-  shell: su -s /bin/sh -c "nova-manage db sync" nova
-
 - name: restart neutron-server
   service: name=neutron-server state=restarted

--- a/roles/nova-controller/tasks/main.yml
+++ b/roles/nova-controller/tasks/main.yml
@@ -23,4 +23,13 @@
     - restart nova-conductor
     - restart nova-novncproxy
     - remove nova-sqlite-db
-    - sync nova-manage-db
+
+- name: nova db sync
+  command: su -s /bin/sh -c "nova-manage db sync" nova
+  notify:
+    - restart nova-api
+    - restart nova-cert
+    - restart nova-consoleauth
+    - restart nova-scheduler
+    - restart nova-conductor
+    - restart nova-novncproxy


### PR DESCRIPTION
nova-manage db_sync was executed after nova servie restart, causing
nova-conductor, nova-scheduler, nova-novncproxy to exit due to lack
of db table, so we need to make sure that nova db sync is executed
before restart of nova services.
