### PR TITLE
create image from file instead of url

### DIFF
--- a/roles/glance/tasks/main.yml
+++ b/roles/glance/tasks/main.yml
@@ -35,6 +35,9 @@
 - name: place image upload script
   template: src=image_upload.sh dest=/opt/image_upload.sh mode=0744
 
+- name: download cirros image file
+  get_url: url={{ build_in_image }} dest=/opt/{{ build_in_image_name }}
+
 - name: wait for 9292 port to become available
   wait_for: port=9292 delay=5
 

--- a/roles/glance/templates/image_upload.sh
+++ b/roles/glance/templates/image_upload.sh
@@ -1,1 +1,1 @@
-glance --os-username=admin --os-password={{ ADMIN_PASS }} --os-tenant-name=admin --os-auth-url=http://controller:35357/v2.0 image-create --name="{{ build_in_image_name }}" --disk-format=qcow2 --container-format=bare --is-public=true --copy-from {{ build_in_image }} && touch glance.import.completed
+glance --os-username=admin --os-password={{ ADMIN_PASS }} --os-tenant-name=admin --os-auth-url=http://controller:35357/v2.0 image-create --name="cirros" --disk-format=qcow2 --container-format=bare --is-public=true < /opt/{{ build_in_image_name }} && touch glance.import.completed


### PR DESCRIPTION
in order to make sure image is created before other notify actions
get executed, restarting mysql for example, which will interrupt
the image creation, create image from file will make sure the image
is active before script continues rather than creating from url
asynchronously.

closes #3
