### PR TITLE
keystone authtoken section is missing in cinder.conf for controller

### DIFF
--- a/roles/cinder-controller/templates/cinder.conf
+++ b/roles/cinder-controller/templates/cinder.conf
@@ -17,5 +17,12 @@ rabbit_userid = guest
 rabbit_password = {{ RABBIT_PASS }}
 my_ip = controller
 
+[keystone_authtoken]
+auth_uri = http://controller:5000/v2.0
+identity_uri = http://controller:35357
+admin_tenant_name = service
+admin_user = cinder
+admin_password = {{ CINDER_PASS }}
+
 [database]
 connection = mysql://cinder:{{ CINDER_DBPASS }}@controller/cinder

--- a/roles/cinder-volume/templates/cinder.conf
+++ b/roles/cinder-volume/templates/cinder.conf
@@ -15,18 +15,14 @@ rabbit_host = controller
 rabbit_port = 5672
 rabbit_userid = guest
 rabbit_password = {{ RABBIT_PASS }}
-
-glance_host = controller
-
-[database]
-connection = mysql://cinder:{{CINDER_DBPASS}}@controller/cinder
+my_ip = controller
 
 [keystone_authtoken]
 auth_uri = http://controller:5000/v2.0
-# auth_host = controller
-# auth_port = 35357
-# auth_protocol = http
 identity_uri = http://controller:35357
 admin_tenant_name = service
 admin_user = cinder
 admin_password = {{ CINDER_PASS }}
+
+[database]
+connection = mysql://cinder:{{ CINDER_DBPASS }}@controller/cinder


### PR DESCRIPTION
causing cinder api to fail due to authorized token.
Moreover, there is no need to maintain to copies of cinder.conf
template as it will cause inconsistency. we should aggregate the
common parts in cinder-common role in the future.

closes #5
