### PR TITLE
update horizon task and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,15 +24,11 @@ For debugging, when VMs are running, do vagrant ssh { node_name} (e.g: vagrant s
 
 To rerun, when VMs are running, do vagrant provision { node_name} (e.g: vagrant provision controller)
 
-### Few things to note:
+### Usage:
 
-* When ansible finishes provisioning, do: `vagrant ssh controller` and go to `/user/share/openstack-dashboard` and run `python manage.py runserver 0.0.0.0:8000`
+* Once deployment is up and running, you can visit the dashboard by visit http://{{ controller ip }}/horizon in the browser.
 
-* Open a browser and type in `http://controller:8000`, enter username and password. It will go to `http://controller:8000/horizon`, this page does not exist, removing "horizon" in the address will solve this issue.
-
-* If you don't see "nova" in "availability zone", do `ansible ssh controller` and `sudo service nova-conductor start` to manually bring it up.
-
-* There's still an issue with bringing up instances. It consistently complains that "no valid host was found". They maybe ralated to neutron.
+* You can also "vagrant ssh controller" and "source /opt/admin-openrc.sh"; then you are able to run openstack command lines.
 
 ### References:
 * https://github.com/openstack-ansible/openstack-ansible

--- a/roles/dashboard/tasks/main.yml
+++ b/roles/dashboard/tasks/main.yml
@@ -11,10 +11,12 @@
   apt: name=openstack-dashboard-ubuntu-theme
        state=absent
 
-- name: update dashboard conf
-  template: src=openstack-dashboard.conf
-            dest=/etc/apache2/sites-available/openstack-dashboard.conf
-            backup=yes
+## horizon configuration is already enabled in apache2/conf-enabled
+## by openstack-dashboard package deploy script.
+#- name: update dashboard conf
+#  template: src=openstack-dashboard.conf
+#            dest=/etc/apache2/sites-available/openstack-dashboard.conf
+#            backup=yes
 
 - name: update horizon settings
   template: src=local_settings.py dest=/etc/openstack-dashboard/local_settings.py

--- a/roles/keystone/tasks/main.yml
+++ b/roles/keystone/tasks/main.yml
@@ -30,7 +30,7 @@
     creates: keystone_init_complete 
 
 - name: keystone source files
-  template: src={{ item }} dest=~/{{ item }}
+  template: src={{ item }} dest=/opt/{{ item }}
   with_items:
     - admin-openrc.sh
     - demo-openrc.sh


### PR DESCRIPTION
horizon can be loaded from apache2 by wsgi, so no need to start
django server manually. and openstack-dashboard.conf is already
built in the openstack-dashboard package, so adding it in site
config is not necessary.
other issues decribed in readme has also been fixed, so delete
them and add usage instructions.
